### PR TITLE
fix: remove joinABPAsync reference

### DIFF
--- a/examples/ScheduledAsync/ScheduledAsync.ino
+++ b/examples/ScheduledAsync/ScheduledAsync.ino
@@ -97,7 +97,7 @@ void start_join()
   //modem.setDevAddr("00000000");
   //modem.setNwkSKey("00000000000000000000000000000000");
   //modem.setAppSKey("00000000000000000000000000000000");
-  //modem.joinABPAsync();
+  //modem.joinABP();
 
   lora_state = JOINING;
 }

--- a/examples/SimpleAsync/SimpleAsync.ino
+++ b/examples/SimpleAsync/SimpleAsync.ino
@@ -52,7 +52,7 @@ void setup()
   //modem.setDevAddr("00000000");
   //modem.setNwkSKey("00000000000000000000000000000000");
   //modem.setAppSKey("00000000000000000000000000000000");
-  //modem.joinABPAsync();
+  //modem.joinABP();
 
   wait_for_idle();
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -60,7 +60,6 @@ joinOTAAAsync	KEYWORD2
 setDevAddr	KEYWORD2
 setNwkSKey	KEYWORD2
 setAppSKey	KEYWORD2
-joinABPAsync	KEYWORD2
 endPacketAsync	KEYWORD2
 getDownlinkPort	KEYWORD2
 setMaintainNeededCallback	KEYWORD2


### PR DESCRIPTION
With ABP mode, an end device skips the join procedure and so it is not blocking.
As explained in the documentation of the [joinABP](https://github.com/stm32duino/STM32LoRaWAN/blob/5029c901f0b35d8f9ae14ff57a52bf1f4087b2b7/src/STM32LoRaWAN.h#L173-L175):

"An ABP join returns immediately, it does not need to wait for the network, so there is no separate non-blocking/async version of this method."

Fixes #28