### PR TITLE
Add Battery Status callback

### DIFF
--- a/src/STM32LoRaWAN.cpp
+++ b/src/STM32LoRaWAN.cpp
@@ -125,6 +125,17 @@ void STM32LoRaWAN::MacProcessNotify()
     instance->maintain_needed_callback();
 }
 
+uint8_t STM32LoRaWAN::GetBatteryLevel()
+{
+  // Called by the stack from an ISR when there is a DevStatusReq
+  uint8_t battery_level = BAT_LEVEL_NO_MEASURE;
+  if (instance->battery_level_callback) {
+      battery_level = instance->battery_level_callback();
+  }
+
+  return battery_level;
+}
+
 void STM32LoRaWAN::maintain()
 {
   if (mac_process_pending) {

--- a/src/STM32LoRaWAN.h
+++ b/src/STM32LoRaWAN.h
@@ -790,6 +790,18 @@ class STM32LoRaWAN : public Stream {
      */
     void setMaintainNeededCallback(std::function<void(void)> callback) { this->maintain_needed_callback = callback; }
 
+    /**
+     * Registers a callback that is called whenever there is a DevStatusReq.
+     *
+     * BAT_LEVEL_EXT_SRC - The end-device is connected to an external power source
+     * BAT_LEVEL_EMPTY - The battery is empty
+     * 1..254 - The battery level, 1 being at minimum and 254 being at maximum
+     * BAT_LEVEL_FULL - The battery is full
+     * BAT_LEVEL_NO_MEASURE - The end-device was not able to measure the battery level
+     *
+     * \NotInMKRWAN
+     */
+    void setBatteryLevelCallback(std::function<uint8_t(void)> callback) { this->battery_level_callback = callback; }
     /// @}
 
     /**
@@ -957,6 +969,7 @@ class STM32LoRaWAN : public Stream {
     static void MacMlmeConfirm(MlmeConfirm_t *MlmeConfirm);
     static void MacMlmeIndication(MlmeIndication_t *MlmeIndication, LoRaMacRxStatus_t *RxStatus);
     static void MacProcessNotify();
+    static uint8_t GetBatteryLevel();
 
     static STM32LoRaWAN *instance;
 
@@ -968,7 +981,7 @@ class STM32LoRaWAN : public Stream {
     };
 
     LoRaMacCallback_t LoRaMacCallbacks = {
-      .GetBatteryLevel = nullptr,
+      .GetBatteryLevel = GetBatteryLevel,
       .GetTemperatureLevel = nullptr,
       .GetUniqueId = nullptr, // Not needed, we just explicitly set the deveui in begin()
       .GetDevAddress = nullptr, // Not needed, user explicitly configures devaddr
@@ -1046,6 +1059,7 @@ class STM32LoRaWAN : public Stream {
     uint32_t fcnt_down = 0;
 
     std::function<void(void)> maintain_needed_callback;
+    std::function<uint8_t(void)> battery_level_callback;
 
     bool mac_process_pending = false;
 


### PR DESCRIPTION
## Add Battery Status callback

**Summary**

<!-- Summary of the PR -->

This PR implements the following **feature**

* [x] Battery Status callback on DevStatusReq


<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Adds the ability to change the Battery Status byte when a DevStatusReq is made from the gateway

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Validation**

```

uint8_t battery_level_callback()
{
  return random(0, 256);  
}

void setup()
{
   modem.begin(EU868);
   modem.setBatteryLevelCallback(battery_level_callback);
    ...
    ...
}

```