### PR TITLE
fix: do not attach Seconds Interrupt

### DIFF
--- a/src/STM32LoRaWAN.cpp
+++ b/src/STM32LoRaWAN.cpp
@@ -75,7 +75,6 @@ bool STM32LoRaWAN::begin(_lora_band band)
   _rtc.begin(true, STM32RTC::HOUR_24);
   /* Attach the callback function before enabling Interrupt */
   _rtc.attachInterrupt(UTIL_TIMER_IRQ_MAP_PROCESS, STM32RTC::ALARM_B);
-  _rtc.attachSecondsInterrupt(TIMER_IF_SSRUCallback);
   /* The subsecond alarm B is set during the StartTimerEvent */
 
   UTIL_TIMER_Init(_rtc.getHandle());


### PR DESCRIPTION
Fixes #36.

Tested with LowPowerBasic
![image](https://github.com/user-attachments/assets/505f07cd-be9e-47e8-8e4a-c3268c589029)

