### PR TITLE
Give application access to RSSI and SNR values of downlink packets.

### DIFF
--- a/src/STM32LoRaWAN.cpp
+++ b/src/STM32LoRaWAN.cpp
@@ -1305,6 +1305,8 @@ void STM32LoRaWAN::MacMcpsIndication(McpsIndication_t* i, LoRaMacRxStatus_t* sta
   if ((i->McpsIndication == MCPS_CONFIRMED || i->McpsIndication == MCPS_UNCONFIRMED) && i->Status == LORAMAC_EVENT_INFO_STATUS_OK) {
     instance->add_rx(i->Buffer, i->BufferSize);
     instance->rx_port = i->Port;
+    instance->rx_rssi = status->Rssi;
+    instance->rx_snr = status->Snr;
   }
 }
 

--- a/src/STM32LoRaWAN.h
+++ b/src/STM32LoRaWAN.h
@@ -299,6 +299,16 @@ class STM32LoRaWAN : public Stream {
      * Returns the port number of the most recently received packet.
      */
     uint8_t getDownlinkPort() { return rx_port; }
+
+    /**
+     * Returns the RSSI of the most recently received packet.
+     */
+    int16_t getDownlinkRssi() { return rx_rssi; }
+
+    /**
+     * Returns the SNR of the most recently received packet.
+     */
+    int8_t getDownlinkSnr() { return rx_snr; }
     /// @}
 
 
@@ -1044,6 +1054,12 @@ class STM32LoRaWAN : public Stream {
 
     /** Port for most recently received packet */
     uint8_t rx_port = 0;
+
+    /** RSSI for most recently received packet */
+    int16_t rx_rssi = 0;
+
+    /** SNR for most recently received packet */
+    int8_t rx_snr = 0;
 
     bool nwk_key_set = false;
 


### PR DESCRIPTION
**Summary**

This PR exposes the RSSI and SNR values of the most recently received packet to the application layer.

This has been supported by RAK RUI3, and when porting to STM32duino I was missing it.
https://docs.rakwireless.com/product-categories/software-apis-and-libraries/rui3/lorawan/
